### PR TITLE
Avoid duplication in jobs defintion.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   linux_build:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
`runs-on` accepts an array, so we can specify multiple target OSes that way.