### PR TITLE
Avoid duplication in jobs defintion.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  linux_build:
+  build:
     runs-on: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   linux_build:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -22,26 +22,3 @@ jobs:
     - name: Run no_std test
       run: cd finny_nostd_tests && cargo build && cargo run
 
-  windows_build:
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run no_std test
-      run: cd finny_nostd_tests && cargo build && cargo run
-
-  macos_build:
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run no_std test
-      run: cd finny_nostd_tests && cargo build && cargo run


### PR DESCRIPTION
`runs-on` accepts an array, so we can specify multiple target OSes that way.