### PR TITLE
Avoid duplication in jobs defintion.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,11 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  linux_build:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -22,26 +25,3 @@ jobs:
     - name: Run no_std test
       run: cd finny_nostd_tests && cargo build && cargo run
 
-  windows_build:
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run no_std test
-      run: cd finny_nostd_tests && cargo build && cargo run
-
-  macos_build:
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run no_std test
-      run: cd finny_nostd_tests && cargo build && cargo run


### PR DESCRIPTION
Jobs definition allows specifying a matrix strategy which is useful for running jobs on multipls machines.