### PR TITLE
Add an implementation for FSM inspection with tracing crate.

### DIFF
--- a/finny/Cargo.toml
+++ b/finny/Cargo.toml
@@ -15,11 +15,13 @@ derive_more = "0.99"
 finny_derive = { path = "../finny_derive", version = "0.2.0" }
 arraydeque = { version = "0.4", default-features = false }
 slog = { version = "2.7", optional = true, default-features = false }
+tracing = { version = "0.1", optional = true, default-features = false }
 heapless = { version = "0.7" }
 
 [features]
 default = ["std", "inspect_slog", "timers_std"]
 std = ["arraydeque/std", "timers_std", "slog/std", "finny_derive/std"]
 inspect_slog = ["slog"]
+inspect_tracing = ["tracing"]
 timers_std = []
 generate_plantuml = ["finny_derive/generate_plantuml"]

--- a/finny/src/inspect/mod.rs
+++ b/finny/src/inspect/mod.rs
@@ -4,3 +4,6 @@ pub mod null;
 
 #[cfg(feature = "inspect_slog")]
 pub mod slog;
+
+#[cfg(feature = "inspect_tracing")]
+pub mod tracing;

--- a/finny/src/inspect/tracing.rs
+++ b/finny/src/inspect/tracing.rs
@@ -1,0 +1,108 @@
+extern crate alloc;
+
+use crate::lib::*;
+use crate::{FsmBackend, FsmBackendImpl, FsmEvent, Inspect, InspectEvent, InspectFsmEvent};
+use alloc::format;
+use alloc::string::ToString;
+use core::any::Any;
+use core::fmt::Debug;
+use tracing::{error, info};
+use AsRef;
+
+#[derive(Default)]
+pub struct InspectTracing {}
+
+impl InspectTracing {
+    pub fn new() -> Self {
+        InspectTracing::default()
+    }
+}
+
+impl Inspect for InspectTracing {
+    fn new_event<F: FsmBackend>(
+        &self,
+        event: &FsmEvent<<F as FsmBackend>::Events, <F as FsmBackend>::Timers>,
+        fsm: &FsmBackendImpl<F>,
+    ) -> Self {
+        let event_display = match event {
+            FsmEvent::Timer(t) => format!("Fsm::Timer({:?})", t),
+            _ => event.as_ref().to_string(),
+        };
+
+        let current_state = format!("{:?}", fsm.get_current_states());
+
+        info!(
+            event = event_display,
+            start_state = current_state,
+            "Dispatching"
+        );
+        InspectTracing {}
+    }
+
+    fn for_transition<T>(&self) -> Self {
+        let transition = type_name::<T>();
+        info!(transition = transition, "Matched transition");
+        InspectTracing {}
+    }
+
+    fn for_sub_machine<FSub: FsmBackend>(&self) -> Self {
+        let sub_fsm = type_name::<FSub>();
+        info!(sub_fsm = sub_fsm, "Dispatching to a submachine");
+        InspectTracing {}
+    }
+
+    fn for_timer<F>(&self, timer_id: <F as FsmBackend>::Timers) -> Self
+    where
+        F: FsmBackend,
+    {
+        info!(timer_id = format!("{:?}", timer_id), "");
+        InspectTracing {}
+    }
+
+    fn on_guard<T>(&self, guard_result: bool) {
+        let guard = type_name::<T>();
+        info!(
+            "Guard {guard} evaluated to {guard_result}",
+            guard = guard,
+            guard_result = guard_result
+        );
+    }
+
+    fn on_state_enter<S>(&self) {
+        let state = type_name::<S>();
+        info!("Entering {state}", state = state);
+    }
+
+    fn on_state_exit<S>(&self) {
+        let state = type_name::<S>();
+        info!("Exiting {state}", state = state);
+    }
+
+    fn on_action<S>(&self) {
+        let action = type_name::<S>();
+        info!("Executing {action}", action = action);
+    }
+
+    fn event_done<F: FsmBackend>(self, fsm: &FsmBackendImpl<F>) {
+        let states = format!("{:?}", fsm.get_current_states());
+        info!(stop_state = states, "Dispatch done");
+    }
+
+    fn on_error<E>(&self, msg: &str, error: &E)
+    where
+        E: Debug,
+    {
+        let error_msg = format!("{:?}", error);
+        error!(error = error_msg, "{}", msg);
+    }
+
+    fn info(&self, msg: &str) {
+        info!("{}", msg);
+    }
+}
+
+impl InspectEvent for InspectTracing {
+    fn on_event<S: Any + Debug + Clone>(&self, event: &InspectFsmEvent<S>) {
+        info!("Inspection event {:?}", event);
+    }
+}

--- a/finny_tests/Cargo.toml
+++ b/finny_tests/Cargo.toml
@@ -6,7 +6,9 @@ publish = false
 edition = "2021"
 
 [dependencies]
-finny = { path = "../finny/" }
+finny = { path = "../finny/", features = ["inspect_tracing"] }
 slog = "2.7"
 slog-term = "2.6"
 slog-async = "2.6"
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/finny_tests/tests/fsm_inspect_tracing.rs
+++ b/finny_tests/tests/fsm_inspect_tracing.rs
@@ -1,0 +1,79 @@
+use finny::inspect::tracing::InspectTracing;
+use finny::{finny_fsm, timers::std::TimersStd, FsmEventQueueVec, FsmFactory, FsmResult};
+use tracing::{info, Level};
+
+#[derive(Default)]
+pub struct Context {
+    temperature: u32,
+}
+
+#[derive(Default)]
+pub struct Normal;
+
+#[derive(Default)]
+pub struct EvaluatingTemperature;
+
+#[derive(Default)]
+pub struct TooHot;
+
+#[derive(Clone)]
+pub struct NewTempReading(u32);
+#[derive(Clone)]
+pub struct HighTemperature;
+
+#[derive(Clone)]
+pub struct Noop;
+
+#[finny_fsm]
+fn my_fsm(mut fsm: FsmBuilder<MyFsm, Context>) -> BuiltFsm {
+    fsm.state::<Normal>()
+        .on_entry(|_state, _ctx| {
+            info!("Normal");
+        })
+        .on_event::<NewTempReading>()
+        .transition_to::<EvaluatingTemperature>()
+        .action(|ev, ctx, _state_a, _state_b| {
+            ctx.context.temperature = ev.0;
+        });
+    fsm.state::<EvaluatingTemperature>()
+        .on_entry(|_state, ctx| {
+            info!("EvaluatingTemperature");
+            if ctx.temperature > 50 {
+                ctx.queue.enqueue(HighTemperature {}).unwrap();
+            } else {
+                ctx.queue.enqueue(Noop {}).unwrap();
+            }
+        })
+        .on_event::<HighTemperature>()
+        .transition_to::<TooHot>();
+    fsm.state::<EvaluatingTemperature>()
+        .on_event::<Noop>()
+        .transition_to::<Normal>();
+    fsm.state::<TooHot>().on_entry(|_state, _ctx| {
+        info!("TooHot");
+    });
+    fsm.initial_state::<Normal>();
+    fsm.build()
+}
+
+#[test]
+fn test_inspect_tracing() -> FsmResult<()> {
+    tracing_subscriber::fmt()
+        .with_file(true)
+        .with_level(true)
+        .with_line_number(true)
+        .with_max_level(Level::TRACE)
+        .with_target(false)
+        .with_thread_names(true)
+        .init();
+
+    let mut fsm = MyFsm::new_with(
+        Context::default(),
+        FsmEventQueueVec::new(),
+        InspectTracing::new(),
+        TimersStd::new(),
+    )?;
+    fsm.start()?;
+    fsm.dispatch(NewTempReading(100))?;
+    Ok(())
+}


### PR DESCRIPTION
So far this is a basic implementation just to get it to work. For future improvements we can consider (a) changing the reported location of the code that emitted log entry, and (b) utilize spans when logging events. Keeping this behind a non-default feature flag for now.